### PR TITLE
Add example taking only 2 arguments of `derivation-path` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ index 0) of the Bitcoin coin type (coin type "BTC").
 ;; => "m/44'/0'/0'/0/0"
 ```
 
+A second version of `derivation-path` takes only 2 arguments a
+`coin-type` and an `account` index to derive an account address.
+
+```clojure
+(derivation-path "BTC" 0)
+;; => "m/44'/0'/0'"
+```
+
 Reference
 ---------
 

--- a/src/bips/bip44.clj
+++ b/src/bips/bip44.clj
@@ -41,4 +41,5 @@
 
 (comment
   (derivation-path "BTC" 0 :external 0)
-  (derivation-path "XMR" 0 :change 0))
+  (derivation-path "XMR" 0 :change 0)
+  (derivation-path "BTC" 0))


### PR DESCRIPTION
# Description

Add an example taking only 2 arguments of `derivation-path` in README.md and in rich comment in `bip44.clj`