### PR TITLE
Add xmr-utils with utils functions for Monero

### DIFF
--- a/src/bips/btc_utils.clj
+++ b/src/bips/btc_utils.clj
@@ -20,10 +20,22 @@
 (ns bips.btc-utils
   (:require
     [alphabase.base58 :as base58]
+    [bips.bip32 :as bip32]
+    [bips.bip39 :as bip39]
     [buddy.core.codecs :as codecs]
     [clj-commons.digest :as digest])
   (:import
     org.apache.commons.codec.binary.Hex))
+
+(defn derive-from-mnemonic
+  "Derive from a BIP039 mnemonic seed to a spend key for Monero."
+  ([mnemonic path key-type]
+   (-> (bip39/mnemonic->seed mnemonic)
+       (bip32/derive-path path key-type)
+       (:private-key)))
+
+  ([{:keys [mnemonic path key-type]}]
+   (derive-from-mnemonic mnemonic path key-type)))
 
 (defn privatekey->wif
   "Convert an hexadecimal encoded private key to WIF"

--- a/src/bips/xmr_utils.clj
+++ b/src/bips/xmr_utils.clj
@@ -1,0 +1,216 @@
+;; Copyright © 2022 CicadaBank
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy of
+;; this software and associated documentation files (the "Software"), to deal in
+;; the Software without restriction, including without limitation the rights to
+;; use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+;; the Software, and to permit persons to whom the Software is furnished to do so,
+;; subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+;; FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+;; COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+;; IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+(ns bips.xmr-utils
+  (:require
+    [alphabase.base58 :as b58]
+    [bips.bip32 :as bip32]
+    [bips.bip32-utils :as bip32-utils]
+    [bips.bip39 :as bip39]
+    [buddy.core.codecs :as codecs]
+    [clojure.math.numeric-tower :as math])
+  (:import
+    org.bouncycastle.jcajce.provider.digest.Keccak$Digest256))
+
+(defn bytes->int
+  "Converts a byte array into a big integer.
+  It has an optional parameter `little-endian`, which defaults to true.
+  If little-endian is true, the byte array is reversed before the conversion"
+  [^bytes bytes & {:keys [little-endian]
+                   :or {little-endian true}}]
+  (let [b (if little-endian (reverse bytes) bytes)]
+    (->> b
+         (cons (byte 0))
+         (byte-array)
+         (biginteger))))
+
+(defn- complement-solution
+  "Pad leading zeros do a 128 bits number in hexadecimal notation."
+  [k]
+  (str (apply str (take (- 64 (count k)) (repeat "0"))) k))
+
+(defn sc-reduce32
+  "Not every 256-bit integer is a valid EdDSA scalar (private key); it must be less than the ``curve order``.
+  `sc_reduce32` is the function to do this.
+  2^252 + 27742317777372353535851937790883648493 is the order of Edwards curve 25519. It is also known as the prime l.
+  This prime l is chosen such that it is a large prime number and also it is close to 2^252."
+  [s]
+  (let [n (bytes->int (codecs/hex->bytes s))
+        l (biginteger (+ (math/expt 2 252) 27742317777372353535851937790883648493))
+        reduced-input (biginteger (.mod n l))
+        pre-result (.toByteArray reduced-input)
+        result (.toString (bytes->int pre-result) 16)]
+    (complement-solution result)))
+
+(defn keccak-256
+  "Cryptographic hash function"
+  [private-key]
+  (let [md (Keccak$Digest256.)
+        _ (.update md (codecs/hex->bytes private-key))
+        digest (.digest md)]
+    (codecs/bytes->hex digest)))
+
+(defn exp-mod
+  "Calculates the result of a modular exponentiation of a given base `b`, exponent `e`, and modulus `m`."
+  [b e m]
+  (if (= e 0)
+    (biginteger 1)
+    (let [t (atom (.mod  (.pow (exp-mod (biginteger b) (.divide (biginteger e) (biginteger 2)) m) 2) m))]
+      (when (not= (.and (biginteger e) (biginteger 1)) 0)
+        (reset! t (.mod (.multiply @t (biginteger b)) m)))
+      @t)))
+
+;; Prime order (also known as the cofactor) of the Edwards curve 25519
+(def q (biginteger (- (math/expt 2 255) 19)))
+
+(defn inv
+  "Computes the modular multiplicative inverse of `x` modulo `q`.
+  The modular multiplicative inverse of `x` modulo `q` is an integer `y` such that `xy = 1 (mod q)`.
+  It does this by using the function `exp-mod` to calculate the result of ``(x^(q-2)) mod q``."
+  [x]
+  (exp-mod x (.subtract q (biginteger 2)) q))
+
+;; This value is used as the `d` constant in the equation defining the Edwards curve 25519: ``y^2 = x^3 + dx^2y + x``.
+(def d (.multiply (biginteger -121665) (inv (biginteger 121666))))
+
+;; Value of the isogeny map from the curve 25519 to the curve 2^255-19, where q is a prime number.
+;; The variable is used to map a point on the curve 25519 to a point on the curve 2^255-19, by applying the isogeny to the point.
+(def I (exp-mod (biginteger 2) (.divide (.subtract q (biginteger 1)) (biginteger 4)) q))
+
+(defn x-recovery
+  "Recover the `x`-coordinate of a point on the Edwards curve 25519, given the `y`-coordinate."
+  [y]
+  (let [xx (.multiply (.subtract (.pow y 2) (biginteger 1))
+                      (inv (.add (reduce (fn [x y] (.multiply x y)) [d y y]) (biginteger 1))))
+        x (atom (exp-mod xx (.divide (.add q (biginteger 3)) (biginteger 8)) q))]
+    (when (not= (.mod (.subtract (.pow @x 2) xx) q) 0)
+      (reset! x (.mod (.multiply @x I) q)))
+    (when (not= (.mod @x (biginteger 2)) 0)
+      (reset! x (.subtract q @x)))
+    @x))
+
+;; `By`, `Bx` and `B` represent a specific point on the curve called the "base point" or "generator point".
+;; This point is used as a starting point for performing scalar multiplication on the curve
+;; y-coordinate of the base point on the curve.
+(def By (.multiply (biginteger 4) (inv (biginteger 5))))
+
+;; x-coordinate of the base point on the curve
+(def Bx (biginteger (x-recovery By)))
+
+;; The point `(Bx, By)` is a point on the curve and `B` is a short representation of this point.
+(def B [(.mod Bx q) (.mod By q)])
+
+(defn edwards
+  [P Q]
+  (let [x1 (nth P 0)
+        y1 (nth P 1)
+        x2 (nth Q 0)
+        y2 (nth Q 1)
+        x3 (.multiply
+             (.add (.multiply x1 y2) (.multiply x2 y1))
+             (inv (.add (biginteger 1) (reduce (fn [x y] (.multiply x y)) [d x1 x2 y1 y2]))))
+        y3 (.multiply
+             (.add (.multiply y1 y2) (.multiply x1 x2))
+             (inv (.subtract (biginteger 1) (reduce (fn [x y] (.multiply x y)) [d x1 x2 y1 y2]))))]
+    [(.mod x3 q) (.mod y3 q)]))
+
+(defn scalar-multiplication
+  "Ed25519 scalarmult function"
+  [P e]
+  (if (= e 0)
+    [(biginteger 0) (biginteger 1)]
+    (let [Q (atom (scalar-multiplication P (.divide e (biginteger 2))))]
+      (reset! Q (edwards @Q @Q))
+      (when (not= (.and e (biginteger 1)) 0)
+        (reset! Q (edwards @Q P)))
+      @Q)))
+
+(defn encode-point
+  "Converts the coordinates of a point on the Edwards curve 25519 represented as a vector of x and y coordinates into a 32-byte string encoded in hexadecimal format."
+  [P]
+  (let [k (biginteger (nth P 0))
+        l (biginteger (nth P 1))
+        semi-bits (for [i (range 0 255)]
+                    (.and (.shiftRight l (biginteger i)) (biginteger 1)))
+        bits (concat semi-bits (list (.and k (biginteger 1)))) ; 0 - 1
+        placed-bytes (for [i (range 0 32)] ; 0 - 255
+                       (biginteger
+                         (reduce (fn [x1 y1] (.add x1 y1))
+                                 (for [j (range 0 8)]
+                                   (.shiftLeft (biginteger (nth bits (+ (* i 8) j))) j)))))
+        pre-result (byte-array placed-bytes)]
+    (codecs/bytes->hex pre-result)))
+
+(defn ->public-key
+  "Compute public counterparts of private view and spend key"
+  [private-key]
+  (let [private-key-byte-array (codecs/hex->bytes private-key)
+        a (biginteger (bytes->int private-key-byte-array))
+        A (scalar-multiplication B a)]
+    (encode-point A)))
+
+(defn pad-leading-ones
+  "Pad `x` with `1`s (1 is 0 in Base58) if it has less than `n` characters."
+  [n x]
+  (if (< (count x) n)
+    (str (apply str (take (- n (count x)) (repeat "1"))) x)
+    x))
+
+(defn get-primary-public-address
+  "Create the actual Public Address from `public-spend-key` and `public-view-key`"
+  [public-spend-key
+   public-view-key]
+  (let [raw-public-address (str "12" public-spend-key public-view-key)
+        raw-public-address-hash (keccak-256 raw-public-address)
+        public-address (str raw-public-address
+                            (apply str (take 8 raw-public-address-hash)))]
+    (loop [K public-address
+           res ""]
+      (if (> (count K) 10)
+        (recur (apply str
+                      (take-last
+                        (- (count K) 16) K))
+               (str res (pad-leading-ones 11
+                                          (b58/encode
+                                            (codecs/hex->bytes
+                                              (apply str (take 16 K)))))))
+        (str res (pad-leading-ones 7 (b58/encode (codecs/hex->bytes K))))))))
+
+(defn ->hexadecimal-seed
+  "Formats a private key to the hexadecimal seed with sc-reduce."
+  [private-key]
+  (sc-reduce32 private-key))
+
+(defn derive-from-mnemonic
+  "Derive from a BIP039 mnemonic seed to a spend key for Monero."
+  ([mnemonic path key-type]
+   (-> (bip39/mnemonic->seed mnemonic)
+       (bip32/derive-path path key-type)
+       (:private-key)
+       (sc-reduce32)))
+
+  ([{:keys [mnemonic path key-type]}]
+   (derive-from-mnemonic mnemonic path key-type)))
+
+(defn ->private-view-key
+  "Derives a private view key from a private spend key."
+  [private-spend-key]
+  (-> private-spend-key
+      (keccak-256)
+      (sc-reduce32)))

--- a/src/bips/xmr_utils.clj
+++ b/src/bips/xmr_utils.clj
@@ -28,6 +28,10 @@
   (:import
     org.bouncycastle.jcajce.provider.digest.Keccak$Digest256))
 
+(def network-bytes
+  {:mainnet "12"
+   :testnet "35"})
+
 (defn bytes->int
   "Converts a byte array into a big integer.
   It has an optional parameter `little-endian`, which defaults to true.
@@ -173,10 +177,13 @@
     x))
 
 (defn get-primary-public-address
-  "Create the actual Public Address from `public-spend-key` and `public-view-key`"
+  "Create the actual Public Address from `public-spend-key`,
+  `public-view-key` and `network-type` (`:mainnet` or `:testnet`)."
   [public-spend-key
-   public-view-key]
-  (let [raw-public-address (str "12" public-spend-key public-view-key)
+   public-view-key
+   network-type]
+  (let [raw-public-address (str (get network-bytes network-type)
+                                public-spend-key public-view-key)
         raw-public-address-hash (keccak-256 raw-public-address)
         public-address (str raw-public-address
                             (apply str (take 8 raw-public-address-hash)))]

--- a/test/bips/xmr_utils_test.clj
+++ b/test/bips/xmr_utils_test.clj
@@ -30,7 +30,8 @@
         private-view-key (sut/->private-view-key private-spend-key)
         primary-address (sut/get-primary-public-address
                           (sut/->public-key private-spend-key)
-                          (sut/->public-key private-view-key))]
+                          (sut/->public-key private-view-key)
+                          :mainnet)]
     (t/is (= "4d93d393f0f2c4a9837524f9d740fa85af54c464864aa8c16d39ef3409781802"
              private-spend-key))
     (t/is (= "c2e6e8597bb5050e57a98d284faf27edc3587d57cccd8a2b3edfd38cdd23af0b"
@@ -46,7 +47,7 @@
         public-spend-key (sut/->public-key private-spend-key)
         public-view-key (sut/->public-key private-view-key)
         primary-address (sut/get-primary-public-address
-                          public-spend-key public-view-key)]
+                          public-spend-key public-view-key :mainnet)]
     (t/is (= "0ccdf1e0217221deb8d807c1ecdf9c0c00beffbc339cdfa5c203c1a022d9cf01"
              private-spend-key))
     (t/is (= "f303de33534d6a9e46497cf177e12b7bdfaf1405b2a03b5a7074a74b0946a805"

--- a/test/bips/xmr_utils_test.clj
+++ b/test/bips/xmr_utils_test.clj
@@ -1,0 +1,70 @@
+;; Copyright © 2022 CicadaBank
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy of
+;; this software and associated documentation files (the "Software"), to deal in
+;; the Software without restriction, including without limitation the rights to
+;; use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+;; the Software, and to permit persons to whom the Software is furnished to do so,
+;; subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+;; FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+;; COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+;; IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+(ns bips.xmr-utils-test
+  (:require
+    [bips.xmr-utils :as sut]
+    [clojure.test :as t]))
+
+;; test vector from
+;; https://github.com/smessmer/crypto-wallet-gen#2-generate-a-monero-wallet-with-the-same-seed-phrase
+(t/deftest test-vector-1
+  (let [mnemonic-seed "acid employ suggest menu desert pioneer hard salmon consider stuff margin over bus fiction direct useful tornado output forward wing cute chicken ladder hockey"
+        private-spend-key (sut/derive-from-mnemonic mnemonic-seed "m/44H/128H/0H" :private)
+        private-view-key (sut/->private-view-key private-spend-key)
+        primary-address (sut/get-primary-public-address
+                          (sut/->public-key private-spend-key)
+                          (sut/->public-key private-view-key))]
+    (t/is (= "4d93d393f0f2c4a9837524f9d740fa85af54c464864aa8c16d39ef3409781802"
+             private-spend-key))
+    (t/is (= "c2e6e8597bb5050e57a98d284faf27edc3587d57cccd8a2b3edfd38cdd23af0b"
+             private-view-key))
+    (t/is (= "4295Lfg8n2pJiN5eC6YHMGGR4oZ1PuaGJNyNo24wNjrdNPLBSVFFHVEay83fFwJBCWPVumE8xW6wKB6Udj8ttmZoNLDTgsn"
+             primary-address))))
+
+;; test vector from https://github.com/skaht/XMR
+(t/deftest test-vector-2
+  (let [seed "f9a0e73d3cd533368f75ff63cbd97b2100beffbc339cdfa5c203c1a022d9cf11"
+        private-spend-key (sut/->hexadecimal-seed seed)
+        private-view-key (sut/->private-view-key private-spend-key)
+        public-spend-key (sut/->public-key private-spend-key)
+        public-view-key (sut/->public-key private-view-key)
+        primary-address (sut/get-primary-public-address
+                          public-spend-key public-view-key)]
+    (t/is (= "0ccdf1e0217221deb8d807c1ecdf9c0c00beffbc339cdfa5c203c1a022d9cf01"
+             private-spend-key))
+    (t/is (= "f303de33534d6a9e46497cf177e12b7bdfaf1405b2a03b5a7074a74b0946a805"
+             private-view-key))
+    (t/is (= "2794fe656a521e21e4135aa13381b42cbeb180e653deda210f2039ca1009d110"
+             public-spend-key))
+    (t/is (= "d76344d2c5467758f0bcbf03925bc8bf4b659e163ec68c342c7ba94b9679a125"
+             public-view-key))
+    (t/is (= "4387BkqvmwB6fnVf4kwNUb8V5jJbQtWNV6XiSiSw1kXz3pPAy9ooZe6FsqKYLo4b19YzoCJQPxWdy9j9kStsRLLg5B8R4Ke"
+             primary-address))
+    (t/is (= "0ccdf1e0217221deb8d807c1ecdf9c0c00beffbc339cdfa5c203c1a022d9cf01"
+             (sut/sc-reduce32 "f9a0e73d3cd533368f75ff63cbd97b2100beffbc339cdfa5c203c1a022d9cf11")))
+    (t/is (= "fcc659eca955591729400f38c6917e8ae0af1405b2a03b5a7074a74b0946a8d5"
+             (sut/keccak-256 "0ccdf1e0217221deb8d807c1ecdf9c0c00beffbc339cdfa5c203c1a022d9cf01")))
+    (t/is (= "f303de33534d6a9e46497cf177e12b7bdfaf1405b2a03b5a7074a74b0946a805"
+             (sut/sc-reduce32 "fcc659eca955591729400f38c6917e8ae0af1405b2a03b5a7074a74b0946a8d5")))
+    (t/is (= "d76344d2c5467758f0bcbf03925bc8bf4b659e163ec68c342c7ba94b9679a125"
+             (sut/->public-key "f303de33534d6a9e46497cf177e12b7bdfaf1405b2a03b5a7074a74b0946a805")))))
+
+(comment
+  (t/run-all-tests))


### PR DESCRIPTION
Most of the code is [work](https://github.com/kno3comma14/cicada-experiments) from @kno3comma14 that we are adapting to this repository. The idea is to be able to derive path from a common seed and still be able to derive keys for each specific coin. Since XMR and BTC works differently, once we have the derived key, we still need to generate private and public view keys and spend keys. All of that can be done using `xmr_utils.clj`.

Examples:
```clojure
(require '[bips.xmr-utils :refer :all])
;; all info without cicacabank.monero.wallet
(let [ ;; private spend key from BIP32 expended private key
      ;; Example from https://github.com/skaht/XMR
      private-spend-key (derive-from-mnemonic
                         "explain olympic caught soccer ethics retire outdoor giant deposit legal quarter cupboard radar silent palm ecology scrap adapt install bone warm clog fantasy language"
                         "m/47H/128H/0H" :private)
      ;; private view key from private spend key
      ;; Example from https://github.com/skaht/XMR
      private-view-key (->private-view-key private-spend-key)
      public-spend-key (->public-key private-spend-key)
      public-view-key (->public-key private-view-key)
      primary-address (get-primary-public-address public-spend-key
                                                  public-view-key)]
  (println private-spend-key)
  ;; => 0ccdf1e0217221deb8d807c1ecdf9c0c00beffbc339cdfa5c203c1a022d9cf01
  (println private-view-key)
  ;; => f303de33534d6a9e46497cf177e12b7bdfaf1405b2a03b5a7074a74b0946a805
  (println public-spend-key)
  ;; => 2794fe656a521e21e4135aa13381b42cbeb180e653deda210f2039ca1009d110
  (println public-view-key)
  ;; => d76344d2c5467758f0bcbf03925bc8bf4b659e163ec68c342c7ba94b9679a125

  ;; Simple benchmarking
  (time (->public-key private-view-key))
  (time (->public-key private-spend-key))

  (println primary-address)
  ;; => 4387BkqvmwB6fnVf4kwNUb8V5jJbQtWNV6XiSiSw1kXz3pPAy9ooZe6FsqKYLo4b19YzoCJQPxWdy9j9kStsRLLg5B8R4Ke
  )
```

# Known issues

The function `->public-key` still needs to be improved. It takes more than a second to compute and we believe there is room for improvement.