### PR TITLE
Add optional argument to `derivation-path` for setting the `hardened-indicator` symbol

### DIFF
--- a/src/bips/bip44.clj
+++ b/src/bips/bip44.clj
@@ -30,24 +30,25 @@
   specific wallet address.  Throws an exception with an error message
   if the `coin-type` in not found in `coin_types.edn`.  A second
   version taking two arguments is used to derive an account address
-  from a `coin-type`, an `account` index and a configuration map for
-  setting the `hardened-indicator` symbol (e.g ``{:hardened-indicator
-  \"'\"}``)."
-  ([coin-type account chain address {:keys [hardened-indicator]
-                                     :or {hardened-indicator "H"}}]
-   (str (derivation-path coin-type account {:hardened-indicator hardened-indicator})
+  from a `coin-type`, an `account` index and an optional
+  `hardened-indicator` symbol."
+  ([coin-type account chain address hardened-indicator]
+   (str (derivation-path coin-type account hardened-indicator)
         "/" (get const/chain-map chain) "/" address))
-  ([coin-type account {:keys [hardened-indicator]
-                       :or {hardened-indicator "H"}}]
+  ([coin-type account chain address]
+   (derivation-path coin-type account chain address "'"))
+  ([coin-type account hardened-indicator]
    (if-let [matching-coin-type (first (filter #(= (:symbol %) coin-type)
                                               const/coin-types))]
      (str "m/44" hardened-indicator "/" (:coin-type matching-coin-type)
           hardened-indicator "/" account hardened-indicator)
-     (throw (Exception. (str "Coin type " coin-type " not found in coin_types.edn file."))))))
+     (throw (Exception. (str "Coin type " coin-type " not found in coin_types.edn file.")))))
+  ([coin-type account]
+   (derivation-path coin-type account "'")))
 
 (comment
-  (derivation-path "BTC" 0 :external 0 {})
-  (derivation-path "BTC" 0 :external 0 {:hardened-indicator "'"})
-  (derivation-path "XMR" 0 :change 0 {})
-  (derivation-path "BTC" 0 {})
-  (derivation-path "BTC" 0 {:hardened-indicator "'"}))
+  (derivation-path "BTC" 0 :external 0 "H")
+  (derivation-path "BTC" 0 :external 0)
+  (derivation-path "XMR" 0 :change 0 "H")
+  (derivation-path "BTC" 0 "H")
+  (derivation-path "BTC" 0))

--- a/src/bips/bip44.clj
+++ b/src/bips/bip44.clj
@@ -24,22 +24,30 @@
 (defn derivation-path
   "The derivation-path multi-arity function. The first version takes
   four arguments: a `coin-type`, an `account` index, a `chain` type,
-  and an `address` index.  It uses these values to construct a string
-  representing a path to a specific wallet address.  Throws an
-  exception with an error message if the `coin-type` in not found in
-  `coin_types.edn`.  A second version taking two arguments is used to
-  derive an account address from a `coin-type` and an `account`
-  index."
-  ([coin-type account chain address]
-   (str (derivation-path coin-type account) "/" (get const/chain-map chain) "/" address))
-  ([coin-type account]
+  an `address` index and a configuration map for setting the
+  `hardened-indicator` symbol (e.g ``{:hardened-indicator \"'\"}``).
+  It uses these values to construct a string representing a path to a
+  specific wallet address.  Throws an exception with an error message
+  if the `coin-type` in not found in `coin_types.edn`.  A second
+  version taking two arguments is used to derive an account address
+  from a `coin-type`, an `account` index and a configuration map for
+  setting the `hardened-indicator` symbol (e.g ``{:hardened-indicator
+  \"'\"}``)."
+  ([coin-type account chain address {:keys [hardened-indicator]
+                                     :or {hardened-indicator "H"}}]
+   (str (derivation-path coin-type account {:hardened-indicator hardened-indicator})
+        "/" (get const/chain-map chain) "/" address))
+  ([coin-type account {:keys [hardened-indicator]
+                       :or {hardened-indicator "H"}}]
    (if-let [matching-coin-type (first (filter #(= (:symbol %) coin-type)
                                               const/coin-types))]
-     (str "m/44'/" (:coin-type matching-coin-type)
-          "'/" account "'")
+     (str "m/44" hardened-indicator "/" (:coin-type matching-coin-type)
+          hardened-indicator "/" account hardened-indicator)
      (throw (Exception. (str "Coin type " coin-type " not found in coin_types.edn file."))))))
 
 (comment
-  (derivation-path "BTC" 0 :external 0)
-  (derivation-path "XMR" 0 :change 0)
-  (derivation-path "BTC" 0))
+  (derivation-path "BTC" 0 :external 0 {})
+  (derivation-path "BTC" 0 :external 0 {:hardened-indicator "'"})
+  (derivation-path "XMR" 0 :change 0 {})
+  (derivation-path "BTC" 0 {})
+  (derivation-path "BTC" 0 {:hardened-indicator "'"}))

--- a/test/bips/bip44_test.clj
+++ b/test/bips/bip44_test.clj
@@ -25,25 +25,51 @@
 ;; https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#examples
 (t/deftest derivation-path-tests
   (t/is (= "m/44'/0'/0'/0/0"
-           (sut/derivation-path "BTC" 0 :external 0)))
+           (sut/derivation-path "BTC" 0 :external 0 {:hardened-indicator "'"})))
   (t/is (= "m/44'/0'/0'/0/1"
-           (sut/derivation-path "BTC" 0 :external 1)))
+           (sut/derivation-path "BTC" 0 :external 1 {:hardened-indicator "'"})))
   (t/is (= "m/44'/0'/0'/1/0"
-           (sut/derivation-path "BTC" 0 :change 0)))
+           (sut/derivation-path "BTC" 0 :change 0 {:hardened-indicator "'"})))
   (t/is (= "m/44'/0'/0'/1/1"
-           (sut/derivation-path "BTC" 0 :change 1)))
+           (sut/derivation-path "BTC" 0 :change 1 {:hardened-indicator "'"})))
   (t/is (= "m/44'/0'/1'/0/0"
-           (sut/derivation-path "BTC" 1 :external 0)))
+           (sut/derivation-path "BTC" 1 :external 0 {:hardened-indicator "'"})))
   (t/is (= "m/44'/0'/1'/0/1"
-           (sut/derivation-path "BTC" 1 :external 1)))
+           (sut/derivation-path "BTC" 1 :external 1 {:hardened-indicator "'"})))
   (t/is (= "m/44'/0'/1'/1/0"
-           (sut/derivation-path "BTC" 1 :change 0)))
+           (sut/derivation-path "BTC" 1 :change 0 {:hardened-indicator "'"})))
   (t/is (= "m/44'/0'/1'/1/1"
-           (sut/derivation-path "BTC" 1 :change 1))))
+           (sut/derivation-path "BTC" 1 :change 1 {:hardened-indicator "'"})))
+  (t/is (= "m/44H/0H/0H/0/0"
+           (sut/derivation-path "BTC" 0 :external 0 {})))
+  (t/is (= "m/44H/0H/0H/0/1"
+           (sut/derivation-path "BTC" 0 :external 1 {})))
+  (t/is (= "m/44H/0H/0H/1/0"
+           (sut/derivation-path "BTC" 0 :change 0 {})))
+  (t/is (= "m/44H/0H/0H/1/1"
+           (sut/derivation-path "BTC" 0 :change 1 {})))
+  (t/is (= "m/44H/0H/1H/0/0"
+           (sut/derivation-path "BTC" 1 :external 0 {})))
+  (t/is (= "m/44H/0H/1H/0/1"
+           (sut/derivation-path "BTC" 1 :external 1 {})))
+  (t/is (= "m/44H/0H/1H/1/0"
+           (sut/derivation-path "BTC" 1 :change 0 {})))
+  (t/is (= "m/44H/0H/1H/1/1"
+           (sut/derivation-path "BTC" 1 :change 1 {}))))
+
+(t/deftest derivation-path-account-tests
+  (t/is (= "m/44'/0'/0'"
+           (sut/derivation-path "BTC" 0 {:hardened-indicator "'"})))
+  (t/is (= "m/44'/128'/0'"
+           (sut/derivation-path "XMR" 0 {:hardened-indicator "'"})))
+  (t/is (= "m/44H/0H/0H"
+           (sut/derivation-path "BTC" 0 {})))
+  (t/is (= "m/44H/128H/0H"
+           (sut/derivation-path "XMR" 0 {}))))
 
 (t/deftest exeptional-case
   (t/is (thrown-with-msg? Exception #"Coin type .* not found in coin_types.edn file."
-          (sut/derivation-path "WTV" 1 :change 1))))
+          (sut/derivation-path "WTV" 1 :change 1 {}))))
 
 (comment
   (clojure.test/run-all-tests))

--- a/test/bips/bip44_test.clj
+++ b/test/bips/bip44_test.clj
@@ -25,51 +25,51 @@
 ;; https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#examples
 (t/deftest derivation-path-tests
   (t/is (= "m/44'/0'/0'/0/0"
-           (sut/derivation-path "BTC" 0 :external 0 {:hardened-indicator "'"})))
+           (sut/derivation-path "BTC" 0 :external 0)))
   (t/is (= "m/44'/0'/0'/0/1"
-           (sut/derivation-path "BTC" 0 :external 1 {:hardened-indicator "'"})))
+           (sut/derivation-path "BTC" 0 :external 1)))
   (t/is (= "m/44'/0'/0'/1/0"
-           (sut/derivation-path "BTC" 0 :change 0 {:hardened-indicator "'"})))
+           (sut/derivation-path "BTC" 0 :change 0)))
   (t/is (= "m/44'/0'/0'/1/1"
-           (sut/derivation-path "BTC" 0 :change 1 {:hardened-indicator "'"})))
+           (sut/derivation-path "BTC" 0 :change 1)))
   (t/is (= "m/44'/0'/1'/0/0"
-           (sut/derivation-path "BTC" 1 :external 0 {:hardened-indicator "'"})))
+           (sut/derivation-path "BTC" 1 :external 0)))
   (t/is (= "m/44'/0'/1'/0/1"
-           (sut/derivation-path "BTC" 1 :external 1 {:hardened-indicator "'"})))
+           (sut/derivation-path "BTC" 1 :external 1)))
   (t/is (= "m/44'/0'/1'/1/0"
-           (sut/derivation-path "BTC" 1 :change 0 {:hardened-indicator "'"})))
+           (sut/derivation-path "BTC" 1 :change 0)))
   (t/is (= "m/44'/0'/1'/1/1"
-           (sut/derivation-path "BTC" 1 :change 1 {:hardened-indicator "'"})))
+           (sut/derivation-path "BTC" 1 :change 1)))
   (t/is (= "m/44H/0H/0H/0/0"
-           (sut/derivation-path "BTC" 0 :external 0 {})))
+           (sut/derivation-path "BTC" 0 :external 0 "H")))
   (t/is (= "m/44H/0H/0H/0/1"
-           (sut/derivation-path "BTC" 0 :external 1 {})))
+           (sut/derivation-path "BTC" 0 :external 1 "H")))
   (t/is (= "m/44H/0H/0H/1/0"
-           (sut/derivation-path "BTC" 0 :change 0 {})))
+           (sut/derivation-path "BTC" 0 :change 0 "H")))
   (t/is (= "m/44H/0H/0H/1/1"
-           (sut/derivation-path "BTC" 0 :change 1 {})))
+           (sut/derivation-path "BTC" 0 :change 1 "H")))
   (t/is (= "m/44H/0H/1H/0/0"
-           (sut/derivation-path "BTC" 1 :external 0 {})))
+           (sut/derivation-path "BTC" 1 :external 0 "H")))
   (t/is (= "m/44H/0H/1H/0/1"
-           (sut/derivation-path "BTC" 1 :external 1 {})))
+           (sut/derivation-path "BTC" 1 :external 1 "H")))
   (t/is (= "m/44H/0H/1H/1/0"
-           (sut/derivation-path "BTC" 1 :change 0 {})))
+           (sut/derivation-path "BTC" 1 :change 0 "H")))
   (t/is (= "m/44H/0H/1H/1/1"
-           (sut/derivation-path "BTC" 1 :change 1 {}))))
+           (sut/derivation-path "BTC" 1 :change 1 "H"))))
 
 (t/deftest derivation-path-account-tests
   (t/is (= "m/44'/0'/0'"
-           (sut/derivation-path "BTC" 0 {:hardened-indicator "'"})))
+           (sut/derivation-path "BTC" 0)))
   (t/is (= "m/44'/128'/0'"
-           (sut/derivation-path "XMR" 0 {:hardened-indicator "'"})))
+           (sut/derivation-path "XMR" 0)))
   (t/is (= "m/44H/0H/0H"
-           (sut/derivation-path "BTC" 0 {})))
+           (sut/derivation-path "BTC" 0 "H")))
   (t/is (= "m/44H/128H/0H"
-           (sut/derivation-path "XMR" 0 {}))))
+           (sut/derivation-path "XMR" 0 "H"))))
 
 (t/deftest exeptional-case
   (t/is (thrown-with-msg? Exception #"Coin type .* not found in coin_types.edn file."
-          (sut/derivation-path "WTV" 1 :change 1 {}))))
+          (sut/derivation-path "WTV" 1 :change 1))))
 
 (comment
   (clojure.test/run-all-tests))


### PR DESCRIPTION
# Description

BIP44 implementation uses a notation like `m/44'/0'`, but when dealing with BIP32 we use `m/44H/0H`.
This PR adds a configuration map argument to `derivation-path` for optionally setting the `:hardened-indicator` symbol.

# How to test

`clojure -X:run/test`