### PR TITLE
Add pre-commit githook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if ! command -v cljstyle &> /dev/null
+then
+    echo "cljstyle could not be found, try to install it following https://github.com/greglook/cljstyle#installation"
+    exit 1
+else
+    set -e
+    cljstyle check --report $(cat <(git diff --name-only) <(git diff --name-only --staged) | sort | uniq)
+fi


### PR DESCRIPTION
# Description

Add pre-commit githook to catch code styling issue at commit time.

# How to test

- Create a symbolic link from `.githooks/pre-commit` to `.git/hooks/pre-commit`
- Add some styling issue to a file then try to commit.